### PR TITLE
new branch with all env hazards stuff

### DIFF
--- a/Content/Unbread/Environment/Hazards/BP_ChoppingKnife.uasset
+++ b/Content/Unbread/Environment/Hazards/BP_ChoppingKnife.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:136193bac7fbf5e94604c1492e231396908d1411358459ae60e1ccdb180659cd
+size 60887

--- a/Content/Unbread/Environment/Hazards/BP_ConveyorBelt.uasset
+++ b/Content/Unbread/Environment/Hazards/BP_ConveyorBelt.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36193fdf11163cae1d6217fc3a96f753997bc1cb6cc8958fa5c98a46b45d8335
+size 219116

--- a/Content/Unbread/Environment/Hazards/BP_FallingKnives.uasset
+++ b/Content/Unbread/Environment/Hazards/BP_FallingKnives.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb618893e5e2b7838ca083ca203ae8b7808cd7a4c4470026f1fa0e9d8f6a14f4
+size 30880

--- a/Content/Unbread/Environment/Hazards/BP_ModularConveyorBelt.uasset
+++ b/Content/Unbread/Environment/Hazards/BP_ModularConveyorBelt.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb365273d3a86b1f36d1676762bb606d393a661108e4a10f2f3e2e12bfdccf66
+size 54493

--- a/Content/Unbread/Environment/Hazards/BP_SpawnKnife.uasset
+++ b/Content/Unbread/Environment/Hazards/BP_SpawnKnife.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:034bbfeaf1184a30e6541e734c21b6ffca2a20b60707eabed7debcf09b9ad907
+size 42754

--- a/Content/Unbread/Maps/HazardsTest01.umap
+++ b/Content/Unbread/Maps/HazardsTest01.umap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcbf469ee9fc5407686a7e1503db869d1d11d17578d09e488b51bb6fd1cccd7f
+size 120544

--- a/Source/unbread/Private/SSpawnableBase.cpp
+++ b/Source/unbread/Private/SSpawnableBase.cpp
@@ -1,0 +1,29 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "SSpawnableBase.h"
+
+// Sets default values
+ASSpawnableBase::ASSpawnableBase()
+{
+ 	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
+	PrimaryActorTick.bCanEverTick = true;
+	MaxTime = 1.0f;
+	InitialVelocity = FVector();
+	
+}
+
+// Called when the game starts or when spawned
+void ASSpawnableBase::BeginPlay()
+{
+	Super::BeginPlay();
+	GetWorld()->GetTimerManager().SetTimer(DeathTimer, this, &ASSpawnableBase::Kill, MaxTime, false);
+}
+
+void ASSpawnableBase::Kill()
+{
+	// TODO object pooling
+	this->Destroy();
+}
+
+

--- a/Source/unbread/Private/S_FallingKnives.cpp
+++ b/Source/unbread/Private/S_FallingKnives.cpp
@@ -1,0 +1,121 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "S_FallingKnives.h"
+
+#include "SCharacter.h"
+#include "Kismet/KismetMathLibrary.h"
+
+// Sets default values
+AS_FallingKnives::AS_FallingKnives()
+{
+
+	PrimaryActorTick.bCanEverTick = true;
+	PrimaryActorTick.bStartWithTickEnabled = true;
+
+	MinSpawnDelay = 0.5f;
+	MaxSpawnDelay = 1.0f;
+	isActive = false;
+	RandomSpawnDelay = 0.0f;
+	SpawnLocation = FVector();
+	TriggerArea = nullptr;
+
+}
+
+// Called when the game starts or when spawned
+void AS_FallingKnives::BeginPlay()
+{
+	Super::BeginPlay();
+	GetBoxComponent();
+	
+}
+
+void AS_FallingKnives::SpawnObject()
+{
+	GEngine->AddOnScreenDebugMessage(-1, 2.0f, FColor::Blue, TEXT("spawn knife"));
+
+	InstantiateObject();
+	InstantiateObject();
+	InstantiateObject();
+
+	
+	// call back if still active
+	if(isActive)
+	{
+		GEngine->AddOnScreenDebugMessage(-1, 2.0f, FColor::Yellow,
+			FString::Printf(TEXT("height: %f"), SpawnHeight));	
+		RandomSpawnDelay = FMath::RandRange(MinSpawnDelay, MaxSpawnDelay);
+		GetWorld()->GetTimerManager().SetTimer(SpawnTimer, this, &AS_FallingKnives::SpawnObject, RandomSpawnDelay, false);
+	}
+}
+
+void AS_FallingKnives::InstantiateObject()
+{
+	// generate random location within collider
+	FVector Origin = TriggerArea->Bounds.Origin;
+	FVector Extent = TriggerArea->Bounds.BoxExtent;
+	SpawnLocation = UKismetMathLibrary::RandomPointInBoundingBox(FVector(Origin.X, Origin.Y, Origin.Z + Extent.Z + SpawnHeight),
+		FVector(Extent.X, Extent.Y, 0.0f));
+
+	// spawn actor
+	FActorSpawnParameters SpawnParams;
+	AActor* SpawnedActor = GetWorld()->SpawnActor<AActor>(ActorToSpawn, SpawnLocation, FRotator(0.0f), SpawnParams);
+}
+
+
+void AS_FallingKnives::GetBoxComponent()
+{
+	// set trigger area to the BoxComponent on the actor
+	TArray<UBoxComponent*> Colliders;
+	GetComponents<UBoxComponent>(Colliders);
+	
+	if(Colliders.Num() > 0)
+	{
+		// bind custom overlap functions
+		TriggerArea = *Colliders.GetData();
+		TriggerArea->OnComponentBeginOverlap.AddDynamic(this, &AS_FallingKnives::OnEnterArea);
+		TriggerArea->OnComponentEndOverlap.AddDynamic(this, &AS_FallingKnives::OnExitArea);
+		
+	}
+	else GEngine->AddOnScreenDebugMessage(-1, 15.0f, FColor::Red, TEXT("No boxcomponent on actor"));	
+}
+
+void AS_FallingKnives::BeginTick()
+{
+	this->SetActorTickEnabled(true);
+}
+
+
+void AS_FallingKnives::OnEnterArea(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor,
+	UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult)
+{
+	if(Cast<ASCharacter>(OtherActor))
+	{
+		isActive = true;
+		RandomSpawnDelay = FMath::RandRange(MinSpawnDelay, MaxSpawnDelay);
+		GetWorld()->GetTimerManager().SetTimer(SpawnTimer, this, &AS_FallingKnives::SpawnObject, RandomSpawnDelay, false);
+	}
+	
+	
+}
+
+void AS_FallingKnives::OnExitArea(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor,
+	UPrimitiveComponent* OtherComp, int32 OtherBodyIndex)
+{
+	// TODO: change this to some sort of interface comparison rather than cast
+	if(Cast<ASCharacter>(OtherActor))
+	{
+		isActive = false;
+		GetWorld()->GetTimerManager().ClearTimer(SpawnTimer);
+			
+	}
+}
+
+
+// Called every frame
+void AS_FallingKnives::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+	// for some reason this actor wont tick TODO
+}
+

--- a/Source/unbread/Public/SSpawnableBase.h
+++ b/Source/unbread/Public/SSpawnableBase.h
@@ -1,0 +1,35 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "SSpawnableBase.generated.h"
+
+UCLASS()
+class UNBREAD_API ASSpawnableBase : public AActor
+{
+	GENERATED_BODY()
+	
+public:	
+	// Sets default values for this actor's properties
+	ASSpawnableBase();
+
+	UPROPERTY(EditAnywhere)
+	FVector InitialVelocity;
+
+	UPROPERTY(EditAnywhere)
+	float MaxTime;
+
+	UFUNCTION()
+	void Kill();
+
+protected:
+	// Called when the game starts or when spawned
+	virtual void BeginPlay() override;
+
+	FTimerHandle DeathTimer;
+
+
+
+};

--- a/Source/unbread/Public/S_FallingKnives.h
+++ b/Source/unbread/Public/S_FallingKnives.h
@@ -1,0 +1,70 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "Components/BoxComponent.h"
+#include "S_FallingKnives.generated.h"
+
+class UBoxComponent;
+UCLASS()
+class UNBREAD_API AS_FallingKnives : public AActor
+{
+	GENERATED_BODY()
+	
+public:	
+	// Sets default values for this actor's properties
+	AS_FallingKnives();
+
+	UPROPERTY(EditAnywhere)
+	UBoxComponent* TriggerArea;
+
+	UPROPERTY(EditDefaultsOnly)
+	TSubclassOf<AActor> ActorToSpawn;
+
+	UPROPERTY(EditAnywhere)
+	float SpawnHeight;
+	
+
+	UFUNCTION()
+	void GetBoxComponent();
+
+	UFUNCTION()
+	void BeginTick();
+	
+	UFUNCTION()
+	void OnEnterArea(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp,
+		int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult);
+
+	UFUNCTION()
+	void OnExitArea(UPrimitiveComponent* OverlappedComponent, AActor* OtherActor, UPrimitiveComponent* OtherComp,
+		int32 OtherBodyIndex);
+
+	// Called every frame
+	virtual void Tick(float DeltaTime) override;
+	
+protected:
+	// Called when the game starts or when spawned
+	virtual void BeginPlay() override;
+
+	UFUNCTION()
+	void SpawnObject();
+
+	UFUNCTION()
+	void InstantiateObject();
+	
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	float MinSpawnDelay;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	float MaxSpawnDelay;
+
+	FTimerHandle SpawnTimer;
+	float RandomSpawnDelay;
+	bool isActive;
+	FVector SpawnLocation;
+	
+
+};


### PR DESCRIPTION
## What?
-Knife spawner area. Area of level that will drop knives on the player periodically when they enter the area. currently no mesh, just white box.
-modular conveyor belts. blueprint objects that add world offset to any actors withing the activation range, to move like a conveyor belt.
-Chopping knives. blueprint objects that have a simple chopping animation that can be delayed by a number of seconds.
-sample level. set up a sample level in 'HazardsMap01' with a some conveyor belts, the knife spawner, and some chopping knives along a conveyor belt.

Had to recreate branch in order to resolve merge conflicts. original work done on EnvironmentalHazards branch.

## why?
Created some simple level mechanics for prototype showcase.

## How?
CPP and Blueprints

## Testing?
added multiple chopping knives to the level, with multiple different delays and directions. conveyor belts work in all directions. with different amounts of force (different per instance of object)

## Anything Else?
chopping and spawned knives currently do not damage the player in any way.