### PR TITLE
Menu Hotfix

### DIFF
--- a/Source/unbread/Private/SNavigatableMenu.cpp
+++ b/Source/unbread/Private/SNavigatableMenu.cpp
@@ -29,6 +29,7 @@ void USNavigatableMenu::AddButton(USMenuButton* Button)
 
 void USNavigatableMenu::Navigate(EDirection Direction)
 {
+	if(!Selected) return;
 	FString Name = Selected->Connections[Direction];
 	
 	if(Name == "") return;


### PR DESCRIPTION
Fixed bug where menu tries to navigate before all buttons are created causing crash, When gameover menu is created and player is still holding an input.