### PR TITLE
adjust Launch Head math

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -157,5 +157,5 @@ ContentBrowserPrefix=/Game/FMOD/
 BankOutputDirectory=(Path="FMOD")
 
 [/Script/Engine.AnimationSettings]
-DefaultFrameRate=(Numerator=60,Denominator=1)
+DefaultFrameRate=(Numerator=120,Denominator=1)
 

--- a/Content/Unbread/Core/Character/BP_Character.uasset
+++ b/Content/Unbread/Core/Character/BP_Character.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a04004e6221ffc956a9a4e527ac6cd936328b7aa2e4c48d0cfc725109a26c96d
-size 302264
+oid sha256:de6850bdfc8bc5f4a4ae18f2a4f571d4c089decaed0dc735beec78906f4bf154
+size 298872

--- a/Content/Unbread/Maps/Testing_Maps/CharacterTestMaps/CharacterTest02.umap
+++ b/Content/Unbread/Maps/Testing_Maps/CharacterTestMaps/CharacterTest02.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b40a9a891e65c6357d1dd1adde3fcbedaf52721e10d4f3ad12644c0bed008723
+oid sha256:4512018153d3ba91576398dbdb0a42ead55ff6c7eb2340e7ba325f00d9511271
 size 99771

--- a/Source/unbread/Private/SCharacter.cpp
+++ b/Source/unbread/Private/SCharacter.cpp
@@ -234,9 +234,12 @@ void ASCharacter::LaunchHead()
 	// Move head forward & launch
 	AddActorWorldOffset(GetMesh()->GetRightVector() * 50.f, true);
 
-	const FVector LaunchVelocity = (GetMesh()->GetRightVector()) * HeadLaunchVelocityMultiplier;	
-	GetCharacterMovement()->Velocity = LaunchVelocity;
+	FVector LaunchVelocity = ((GetMesh()->GetRightVector()) * HeadLaunchVelocityMultiplier);
+	LaunchVelocity.Z += HeadLaunchVelocityZAxisAdd;
+	//GetCharacterMovement()->Velocity = LaunchVelocity;
 
+	GetCharacterMovement()->Launch(LaunchVelocity);
+	
 	// Spawn the body and add it to ActiveBodies
 	FActorSpawnParameters Parameters {};
 	Parameters.bNoFail = true;
@@ -244,7 +247,7 @@ void ASCharacter::LaunchHead()
 	Spawned->Mesh->AddImpulse(-GetMesh()->GetRightVector() * 10 * HeadLaunchVelocityMultiplier);
 	Spawned->SetInstigator(this);
 	ActiveBodies.AddUnique(Spawned);
-
+	
 	Speed = HeadSpeed;
 	
 }

--- a/Source/unbread/Public/SCharacter.h
+++ b/Source/unbread/Public/SCharacter.h
@@ -167,14 +167,14 @@ protected:
 	USkeletalMesh* HeadMesh;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	float HeadLaunchVelocityMultiplier = 2200.f;
+	float HeadLaunchVelocityMultiplier = 200.f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	float HeadLaunchVelocityZAxisAdd = 1200.0f;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	TMap<const AActor*, FCameraOccludedActor> OccludedActors;
 	
-	// TODO: UPDATE TEMPORARY SETUP USING G.A.S.
-
-
 	// GAS setup
 	void OnPrimaryAttack(const FInputActionValue& Value);
 	void OnSecondaryAttack(const FInputActionValue& Value);


### PR DESCRIPTION
### WHAT
Adjusted the math behind Launch Head function

### HOW
In SCharacter.cpp, instead of updating CharacterMovement Velocity, Launch function is now being called with two separate multipliers. One multiplier is for impulse strength, the other one is for Z-Axis velocity of the launch. Both are BP editable for fine tuning.

### WHY
To improve the core character ability.