### PR TITLE
Fix Camera Occlusion Channel & AI death

### DIFF
--- a/Content/Unbread/Core/AI/Melee/BP_MeleeAICharacter.uasset
+++ b/Content/Unbread/Core/AI/Melee/BP_MeleeAICharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2d43da6e467a5137e2d30eb2c162cbd6ae52e85027909f9e9008fe3a843a5852
-size 267074
+oid sha256:8dae1c8b56b52618837fad181d8bf431aa80c1c8ec0a12a74fd1c2f757e2a2f4
+size 261365

--- a/Content/Unbread/Core/AI/Ranged/BP_RangedAICharacter.uasset
+++ b/Content/Unbread/Core/AI/Ranged/BP_RangedAICharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d99b62907cde295fb495f9b604c299e0e076fcc5ac14704bc8385ded9af7fcbe
-size 212344
+oid sha256:b76dd9ac054ad904d5572002f228f4f18ed37f03f702f6a739a76f393ed6bc22
+size 212291

--- a/Source/unbread/Private/SCharacter.cpp
+++ b/Source/unbread/Private/SCharacter.cpp
@@ -453,8 +453,11 @@ void ASCharacter::Tick(float DeltaTime)
 
 	TArray<TEnumAsByte<EObjectTypeQuery>> CollisionObjectTypes;
 
-	CollisionObjectTypes.Add(UEngineTypes::ConvertToObjectType(ECC_WorldStatic));
-	CollisionObjectTypes.Add(UEngineTypes::ConvertToObjectType(ECC_WorldDynamic));
+#define CAMERA_OCCLUSION_CHANNEL ECollisionChannel::ECC_EngineTraceChannel4
+	CollisionObjectTypes.Add(UEngineTypes::ConvertToObjectType(CAMERA_OCCLUSION_CHANNEL));
+
+	//CollisionObjectTypes.Add(UEngineTypes::ConvertToObjectType(ECC_WorldStatic));
+	//CollisionObjectTypes.Add(UEngineTypes::ConvertToObjectType(ECC_WorldDynamic));
 	
 	bool isCollision = UKismetSystemLibrary::CapsuleTraceMultiForObjects(
 	GetWorld(), Start, End, 1,


### PR DESCRIPTION
# What
Camera occlusion now uses the Camera Occlusion Channel
Removed rag dolling from AI when they die until it can be implemented in a more polished state